### PR TITLE
update for api/youtube/latest - adding filter for only sermons

### DIFF
--- a/src/app/api/youtube/latest/route.ts
+++ b/src/app/api/youtube/latest/route.ts
@@ -46,8 +46,11 @@ export async function GET(req: NextRequest) {
           title: item.snippet!.title!,
           publishedAt: item.snippet!.publishedAt,
           thumbnail: item.snippet?.thumbnails?.high?.url, // Get high-resolution thumbnail
-        })
-      ) ?? [];
+        }))
+        .filter((video) => { // Filters for Videos with format: [SERIES] title of sermon
+          const titleRegex = /^\[[A-Z\s]+\]\s.+/;
+          return titleRegex.test(video.title);
+        }) ?? [];
 
     return NextResponse.json(latestVideos, { status: 200 });
   } catch (error: any) {


### PR DESCRIPTION
I documented that `/latest` would be used for all videos but I think we are using it for latest sermons so I made an update to filter only sermon messages based on the title

We can revisit our APIs later but for now this fix will show the correct videos on the website