### PR TITLE
PUT api/events (installed zod for formatting)

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -21,7 +21,8 @@
         "react": "^19.0.0",
         "react-dom": "^19.0.0",
         "tailwind-merge": "^3.1.0",
-        "tailwindcss-animate": "^1.0.7"
+        "tailwindcss-animate": "^1.0.7",
+        "zod": "^3.24.4"
       },
       "devDependencies": {
         "@eslint/eslintrc": "^3",
@@ -8233,6 +8234,15 @@
       },
       "funding": {
         "url": "https://github.com/sponsors/sindresorhus"
+      }
+    },
+    "node_modules/zod": {
+      "version": "3.24.4",
+      "resolved": "https://registry.npmjs.org/zod/-/zod-3.24.4.tgz",
+      "integrity": "sha512-OdqJE9UDRPwWsrHjLN2F8bPxvwJBK22EHLWtanu0LSYr5YqzsaaW3RMgmjwr8Rypg5k+meEJdSPXJZXE/yqOMg==",
+      "license": "MIT",
+      "funding": {
+        "url": "https://github.com/sponsors/colinhacks"
       }
     }
   }

--- a/package.json
+++ b/package.json
@@ -22,7 +22,8 @@
     "react": "^19.0.0",
     "react-dom": "^19.0.0",
     "tailwind-merge": "^3.1.0",
-    "tailwindcss-animate": "^1.0.7"
+    "tailwindcss-animate": "^1.0.7",
+    "zod": "^3.24.4"
   },
   "devDependencies": {
     "@eslint/eslintrc": "^3",

--- a/src/app/api/events/route.ts
+++ b/src/app/api/events/route.ts
@@ -1,8 +1,52 @@
 import { NextResponse } from 'next/server';
 import { get } from '@vercel/edge-config';
+import z from 'zod'; 
+import { getEdgeConfigCredentials } from '@/lib/edge-config';
  
+const EventSchema = z.object({
+  id: z.string(),
+  title: z.string(),
+  date: z.string(), 
+  location: z.string(),
+  description: z.string().optional(),
+});
+
 export async function GET() {
   const val = await get('events');
  
   return NextResponse.json(val);
+}
+
+export async function PUT(req: Request) {
+  const body = await req.json();
+
+  const parsed = z.array(EventSchema).safeParse(body);
+  if (!parsed.success) {
+    return NextResponse.json({ error: "Invalid data format", details: parsed.error }, { status: 400 });
+  }
+
+
+  const { edgeConfigId, token } = getEdgeConfigCredentials(); 
+
+  if (!edgeConfigId || !token) {
+    return NextResponse.json({ error: "Could not extract Edge Config credentials" }, { status: 500 });
+  }
+
+  const res = await fetch(`https://edge-config.vercel.com/${edgeConfigId}/items`, {
+    method: "PATCH",
+    headers: {
+      Authorization: `Bearer ${token}`,
+      "Content-Type": "application/json",
+    },
+    body: JSON.stringify({
+      items: [{ key: "events", value: parsed.data }],
+    }),
+  });
+
+  if (!res.ok) {
+    const error = await res.json();
+    return NextResponse.json({ error: "Failed to update Edge Config", details: error }, { status: 500 });
+  }
+
+  return NextResponse.json({ message: "Events updated successfully" });
 }

--- a/src/app/api/events/route.ts
+++ b/src/app/api/events/route.ts
@@ -4,11 +4,13 @@ import z from 'zod';
 import { getEdgeConfigCredentials } from '@/lib/edge-config';
  
 const EventSchema = z.object({
-  id: z.string(),
+  status: z.string(),
   title: z.string(),
   date: z.string(), 
-  location: z.string(),
-  description: z.string().optional(),
+  time: z.string(),
+  img_url: z.string(),
+  // location: z.string(),
+  // description: z.string().optional(),
 });
 
 export async function GET() {

--- a/src/lib/edge-config.ts
+++ b/src/lib/edge-config.ts
@@ -1,0 +1,19 @@
+export function getEdgeConfigCredentials() {
+/* `vercal env pull` creates env var EDGE_CONFIG. Extract edge config ID and token from this value
+    example) EDGE_CONFIG=https://edge-config.vercel.com/ecfg_xxx/items?token=verc_xxx */
+  const edgeConfigUrl = process.env.EDGE_CONFIG;
+
+  if (!edgeConfigUrl) {
+    throw new Error("Missing EDGE_CONFIG environment variable");
+  }
+
+  const url = new URL(edgeConfigUrl);
+  const edgeConfigId = url.pathname.split("/")[1]; // e.g., "ecfg_xxx"
+  const token = url.searchParams.get("token");
+
+  if (!edgeConfigId || !token) {
+    throw new Error("Failed to extract Edge Config ID or token");
+  }
+
+  return { edgeConfigId, token };
+}


### PR DESCRIPTION
- PUT `api/events` now accepts array of events
- NOTE! It will overwrite the whole value with the new array so please remember to call this API with the full object and not treat it like a PATCH call 
- I added a validator so that each event object in array must follow the following format: 

```
{
  status: z.string(),
  title: z.string(),
  date: z.string(), 
  time: z.string(),
  img_url: z.string(),
},
```

I based this off of what we currently have in our edge-config for events but we can change this to whatever we need moving forward