### PR TITLE
Bug fixes: iOS PDF rendering + sermon ingest

### DIFF
--- a/src/app/api/sermon/ingest/route.ts
+++ b/src/app/api/sermon/ingest/route.ts
@@ -14,24 +14,25 @@ const youtube = google.youtube({
   auth: YOUTUBE_API_KEY,
 });
 
-// Helper: Fetch latest 3 long videos with "Pastor Sermon" in title
+// Helper: Fetch latest sermon videos
+// Sermon titles follow the pattern: "[Series] Title | Pastor [Name] | New Seoul Church (NSC)"
+// Worship videos follow: "Sunday Service Worship | [Date]" — excluded by title filter
 async function fetchLatestVideos() {
   const params: youtube_v3.Params$Resource$Search$List = {
     part: ["snippet"],
     channelId: CHANNEL_ID,
-    q: "Pastor Sermon",
+    q: "New Seoul Church NSC",
     type: ["video"],
-    videoDuration: "long",
     order: "date",
-    maxResults: 5,
+    maxResults: 10,
   };
   const res = await youtube.search.list(params);
   return (
     res.data.items
-      ?.filter(
-        (item) =>
-          item.snippet?.description?.includes("Sermon")
-      )
+      ?.filter((item) => {
+        const title = item.snippet?.title ?? "";
+        return title.includes("| Pastor") && title.includes("New Seoul Church");
+      })
       .map((item) => ({
         videoId: item.id?.videoId,
         title: item.snippet?.title || "",

--- a/src/app/beliefs/page.tsx
+++ b/src/app/beliefs/page.tsx
@@ -73,10 +73,19 @@ export default function LifeGroupPage() {
             CONFESSIONAL STATEMENT
           </h1>
           <div className="w-full max-w-[800px] shadow-xl overflow-hidden border border-gray-300 rounded-[12px]">
+            {/* iOS Safari does not render PDFs in iframes — show a link on mobile */}
+            <a
+              href="/assets/pdfs/confessional.pdf"
+              target="_blank"
+              rel="noopener noreferrer"
+              className="sm:hidden flex items-center justify-center gap-2 w-full py-6 text-base font-medium text-black hover:underline"
+            >
+              View Confessional Statement (PDF)
+            </a>
             <iframe
               src="/assets/pdfs/confessional.pdf#zoom=page-width"
               title="Confessional Statement"
-              className="w-full h-[500px] sm:h-[800px]"
+              className="hidden sm:block w-full h-[800px]"
             />
           </div>
         </div>


### PR DESCRIPTION
## Summary
- Fix iOS PDF rendering on Beliefs page — replace iframe with a tappable link on mobile since iOS Safari does not support PDF embeds in iframes; iframe is preserved for desktop
- Fix sermon ingest cron — previous search query used `"Pastor Sermon"` which no longer matches the channel's title format; sermons now follow `| Pastor [Name] | New Seoul Church (NSC)` pattern; switched to title-based filter and broader search query

## Test plan
- [ ] Open /beliefs on iPhone — confirm PDF link appears and opens natively
- [ ] Manually trigger /api/sermon/ingest and confirm new sermons are picked up