### PR TITLE
SEO, footer updates, social links, and sermon ingest fixes

### DIFF
--- a/src/app/about/page.tsx
+++ b/src/app/about/page.tsx
@@ -3,6 +3,12 @@
 import React from "react";
 import Image from "next/image";
 import ChurchStaff from "@/app/about/church-staff";
+import { Metadata } from "next"
+
+export const metadata: Metadata = {
+  title: "About Us",
+  description: "Meet the staff and community of New Seoul Church.",
+}
 export default function AboutUsPage() {
   return (
     <div className="px-4 sm:px-[85px]">

--- a/src/app/about/page.tsx
+++ b/src/app/about/page.tsx
@@ -12,58 +12,63 @@ export const metadata: Metadata = {
 export default function AboutUsPage() {
   return (
     <div className="px-4 sm:px-[85px]">
-      <section className="flex flex-col lg:flex-row items-center mt-[64px] sm:mt-[104px] py-[24px] sm:py-[31px] gap-6">
-        <div className="lg:w-1/2 lg:pr-6 w-full text-center lg:text-left sm:pl-[25px]">
-          <div className="text-3xl sm:text-4xl font-bold">WHO WE ARE</div>
-          <div className="mt-5 sm:mt-[19px] text-base sm:text-[18px] leading-relaxed">
-            New Seoul Church was birthed in February 2023 with a heart to be a
-            new wineskin for the new wine in the Greater Seoul area. We desire
-            to answer the call to reach all the corners of the city, Be a bridge
-            between internationals and Korean natives, and be forerunners in
-            21st century biblical obedience.
-          </div>
-          <div className="mt-5 sm:mt-[28px] text-base sm:text-[18px] leading-relaxed">
-            We share our stories, along with fellowship, prayer times, reading
-            scriptures, books.
-          </div>
+      <section className="mt-[64px] sm:mt-[104px] py-[24px] sm:py-[31px]">
+        <div className="text-3xl sm:text-4xl font-bold">WHO WE ARE</div>
+        <div className="mt-5 sm:mt-[19px] text-base sm:text-[18px] leading-relaxed">
+          New Seoul Church was birthed in February 2023 with a heart to be a
+          new wineskin for the new wine in the Greater Seoul area. We desire
+          to answer the call to reach all the corners of the city, be a bridge
+          between internationals and Korean natives, and be forerunners in
+          21st century biblical obedience.
         </div>
-
-        <div className="lg:w-1/2 w-full flex justify-center">
+        <div className="mt-5 sm:mt-[28px] text-base sm:text-[18px] leading-relaxed">
+          We share our stories, along with fellowship, prayer times, reading
+          scriptures, books.
+        </div>
+        <div className="mt-8 w-full">
           <Image
             src="/assets/images/about/about-us-image1.jpeg"
-            className="w-full max-w-[595px] h-auto sm:h-[308px] object-cover bg-gray-200 rounded-[18px]"
-            alt="about-us-image1"
-            width={300}
-            height={300}
+            className="w-full h-[340px] sm:h-[480px] object-cover rounded-[18px]"
+            alt="NSC congregation"
+            width={1200}
+            height={480}
           />
         </div>
       </section>
 
       <section className="text-center mt-[64px] sm:mt-[104px] mb-[64px] sm:mb-[97px]">
         <div className="text-2xl sm:text-3xl font-bold">GET TO KNOW US</div>
-        <div className="flex mt-10 sm:mt-[45px] flex-col lg:flex-row items-center gap-6">
-          <div className="w-full lg:w-1/2 flex justify-center">
+        <div className="flex mt-10 sm:mt-[45px] flex-col lg:flex-row items-start gap-8 bg-gray-50 rounded-[18px] p-6 sm:p-10">
+          <div className="w-full lg:w-[38%] flex justify-center flex-shrink-0">
             <Image
               src="/assets/images/about/pjoe-and-family.jpeg"
-              className="w-full max-w-[595px] h-auto sm:h-[417px] object-cover bg-gray-200 rounded-[18px]"
-              alt="pjoe-and-family"
-              width={200}
-              height={200}
+              className="w-full max-w-[420px] h-auto sm:h-[480px] object-cover rounded-[14px]"
+              alt="Pastor Joe and family"
+              width={420}
+              height={480}
             />
           </div>
-          <div className="lg:w-1/2 lg:pr-6 w-full text-center lg:text-left">
+          <div className="lg:w-[62%] w-full text-center lg:text-left">
             <div className="text-2xl sm:text-3xl font-bold">
-              Pastor Joe and Family
+              Pastor Joe, Monica, Eden and Ayla Oh
             </div>
             <div className="mt-4 sm:mt-5 text-base sm:text-[18px] leading-relaxed">
-              Joe Oh - Lead pastor Joe Oh was born and raised in Anaheim, CA.
-              His wife&apos;s name is Monica with two daughters, Eden and Ayla.
-              He graduated from UC San Diego and got his Masters in Divinity in
-              Talbot School of Theology. He has a passion for discipleship and
-              loves to see men of God raised up. Joe Oh has served at Sarang
-              Church Anaheim and Philippi Church OC, as the youth, English
-              ministry and Vision casting pastor. He loves hiking, basketball,
-              and living life with Covenant Fam.
+              The Oh Family Ethos is &ldquo;Putting Jesus first.&rdquo; As a
+              pastor&apos;s son and grandson, P. Joe&apos;s story involves a
+              call before the call, and truly learning to make a birthed faith,
+              his. Monica&apos;s passion is to model Godly couple, Godly family.
+              Consequently, their passion is to model for their kids what it
+              means to live out the Kingdom prerogative, together. If there is
+              one phrase to describe P.Joe it is &ldquo;That&apos;s Life.&rdquo;
+              Always trying to see the blessing in all circumstances, P.Joe
+              finds joy and learning in the journey. This journey includes being
+              born and raised in Orange County, California, college in University
+              of California, San Diego (UCSD), and seminary at Talbot School of
+              Theology, Biola. Ordained in the Presbyterian Church of America
+              (PCA), God called P.Joe out to Korea with a call to bring the
+              gospel to Asia. P.Joe loves challenges (Hiking, biking, Basketball,
+              all things active) and commits to lead others to grow closer to
+              Jesus and to grow to be more like Him.
             </div>
           </div>
         </div>

--- a/src/app/api/sermon/ingest/route.ts
+++ b/src/app/api/sermon/ingest/route.ts
@@ -62,8 +62,12 @@ async function fetchTranscript(videoId: string) {
   return json.content;
 }
 
+// text-embedding-3-large limit is 8191 tokens (~32k chars); truncate to stay safe
+const MAX_EMBEDDING_CHARS = 25000;
+
 // Helper: Get OpenAI embedding
 async function getEmbedding(text: string) {
+  const truncated = text.slice(0, MAX_EMBEDDING_CHARS);
   const res = await fetch("https://api.openai.com/v1/embeddings", {
     method: "POST",
     headers: {
@@ -72,7 +76,7 @@ async function getEmbedding(text: string) {
     },
     body: JSON.stringify({
       model: "text-embedding-3-large",
-      input: text,
+      input: truncated,
       encoding_format: "float",
     }),
   });
@@ -103,7 +107,7 @@ export async function GET(req: Request) {
   let processed = [];
   try {
     const videos = await fetchLatestVideos();
-    for (const { videoId, title, publishedAt } of videos) {
+    for (const { videoId, title, publishedAt } of videos.slice(0, 1)) {
       if (!videoId) continue;
       const exists = await existsInSupabase(videoId);
       if (exists) continue;
@@ -112,6 +116,7 @@ export async function GET(req: Request) {
       if (!transcript) throw new Error("No transcript!");
 
       const embedding = await getEmbedding(transcript);
+      if (!embedding) throw new Error(`Embedding failed for ${videoId}`);
       await insertToSupabase(videoId, title, embedding, publishedAt);
       processed.push({ videoId, title, publishedAt });
     }

--- a/src/app/api/sermon/prompt/route.ts
+++ b/src/app/api/sermon/prompt/route.ts
@@ -73,7 +73,7 @@ export async function GET(req: Request) {
   const results = (data || []).slice(0, 3).map((row: Row) => ({
     videoId: row.id,
     title: row.title,
-    thumbnail: `https://img.youtube.com/vi/${row.id}/hqdefault.jpg`,
+    thumbnail: `https://img.youtube.com/vi/${row.id}/mqdefault.jpg`,
     similarity: row.similarity,
   }));
   if (results.length === 0) {

--- a/src/app/api/sermon/search/route.ts
+++ b/src/app/api/sermon/search/route.ts
@@ -50,7 +50,7 @@ export async function POST(req: Request) {
   const results = (data || []).slice(0, 3).map((row: Row) => ({
     videoId: row.id,
     title: row.title,
-    thumbnail: `https://img.youtube.com/vi/${row.id}/hqdefault.jpg`,
+    thumbnail: `https://img.youtube.com/vi/${row.id}/mqdefault.jpg`,
     similarity: row.similarity,
   }));
   if (results.length === 0) {

--- a/src/app/api/youtube/latest/route.ts
+++ b/src/app/api/youtube/latest/route.ts
@@ -67,7 +67,7 @@ export async function GET(req: NextRequest) {
         id: item.id,
         title: item.title!,
         publishedAt: item.publishedAt,
-        thumbnail: `https://img.youtube.com/vi/${item.id}/hqdefault.jpg`,
+        thumbnail: `https://img.youtube.com/vi/${item.id}/mqdefault.jpg`,
       })) ?? [];
     return NextResponse.json(latestVideos, { status: 200 });
   } catch (error: any) {

--- a/src/app/beliefs/page.tsx
+++ b/src/app/beliefs/page.tsx
@@ -1,5 +1,6 @@
 import VisionCards from "./VisionCards";
 import { Metadata } from "next"
+import { PageHeader } from "@/components/PageHeader"
 
 export const metadata: Metadata = {
   title: "Our Beliefs",
@@ -9,13 +10,9 @@ export const metadata: Metadata = {
 export default function LifeGroupPage() {
   return (
     <div>
-      <section className="h-[300px] sm:h-[436px] flex justify-center items-center px-4">
-        <h1 className="text-[28px] sm:text-h1 font-bold uppercase text-center">
-          our beliefs
-        </h1>
-      </section>
+      <PageHeader title="our beliefs" />
 
-      <section className="py-[16px] px-4 sm:px-[54px]">
+      <section className="py-[16px] px-4 sm:px-[85px]">
         <div className="w-full h-[200px] sm:h-[261px] bg-[#191b2c] rounded-[12px]">
           <div className="flex flex-col items-center justify-center h-full text-center px-2">
             <h1 className="font-bold uppercase text-white text-[18px] sm:text-[20px]">
@@ -28,7 +25,7 @@ export default function LifeGroupPage() {
         </div>
       </section>
 
-      <section className="py-[16px] px-4 sm:px-[54px] relative">
+      <section className="py-[16px] px-4 sm:px-[85px] relative">
         <img
           className="w-full h-[300px] sm:h-full object-cover rounded-[12px]"
           src="/assets/images/ourbeliefs/Our-belief-image1.png"
@@ -73,7 +70,7 @@ export default function LifeGroupPage() {
       </section>
 
       {/* Confessional Statement */}
-      <section className="py-[16px] px-4 sm:px-[54px] mt-[90px]">
+      <section className="py-[16px] px-4 sm:px-[85px] mt-[90px]">
         <div className="flex flex-col items-center justify-center text-center">
           <h1 className="font-bold uppercase text-[18px] sm:text-[20px] mb-[24px] sm:mb-[38px]">
             CONFESSIONAL STATEMENT

--- a/src/app/beliefs/page.tsx
+++ b/src/app/beliefs/page.tsx
@@ -1,4 +1,10 @@
 import VisionCards from "./VisionCards";
+import { Metadata } from "next"
+
+export const metadata: Metadata = {
+  title: "Our Beliefs",
+  description: "Learn about the vision and theology of New Seoul Church.",
+}
 
 export default function LifeGroupPage() {
   return (

--- a/src/app/events/layout.tsx
+++ b/src/app/events/layout.tsx
@@ -1,0 +1,11 @@
+import { Metadata } from "next"
+import { ReactNode } from "react"
+
+export const metadata: Metadata = {
+  title: "Events",
+  description: "Upcoming events at New Seoul Church.",
+}
+
+export default function EventsLayout({ children }: { children: ReactNode }) {
+  return <>{children}</>
+}

--- a/src/app/events/page.tsx
+++ b/src/app/events/page.tsx
@@ -82,11 +82,11 @@ export default function EventsPage() {
     getEvents();
   }, []);
   return (
-    <div className="px-4 sm:px-[55px]">
-      <section className="flex flex-col lg:flex-row items-center mt-[77px] py-[31px] gap-6">
+    <div className="px-4 sm:px-[85px]">
+      <section className="flex flex-col lg:flex-row items-center mt-[64px] sm:mt-[104px] py-[31px] gap-6">
         <div className="lg:w-1/2 lg:pr-6 w-full text-center lg:text-left">
-          <div className="text-3xl sm:text-4xl font-bold">EVENTS</div>
-          <div className="mt-4 sm:mt-[28px] text-sm sm:text-base">
+          <div className="text-[28px] sm:text-4xl font-bold uppercase">EVENTS</div>
+          <div className="mt-4 sm:mt-[28px] text-base sm:text-[18px] leading-relaxed">
             Celebrating our life together as a church is such a blessing.
             <br />
             There are many events going on throughout the year.
@@ -108,7 +108,7 @@ export default function EventsPage() {
       <EventCardList eventsData={upcomingEvents} />
 
       <section className="mt-[65px] mb-[27px]">
-        <div className="text-2xl sm:text-h3 font-bold text-center sm:text-left mb-6">
+        <div className="text-2xl sm:text-3xl font-bold text-center sm:text-left mb-6">
           PAST
         </div>
         <EventCardList eventsData={pastEvents} />

--- a/src/app/layout.tsx
+++ b/src/app/layout.tsx
@@ -3,6 +3,25 @@ import { ReactNode } from "react"
 import { Analytics } from "@vercel/analytics/next"
 import Header from "@/components/layout/Header"
 import Footer from "@/components/layout/Footer"
+import { Metadata } from "next"
+
+export const metadata: Metadata = {
+  title: {
+    default: "New Seoul Church",
+    template: "%s | New Seoul Church",
+  },
+  description:
+    "New Seoul Church is a gospel-centered church in Seoul, Korea. Join us Sundays at 11:00am.",
+  metadataBase: new URL("https://newseoulchurch.org"),
+  openGraph: {
+    title: "New Seoul Church",
+    description:
+      "New Seoul Church is a gospel-centered church in Seoul, Korea. Join us Sundays at 11:00am.",
+    url: "https://newseoulchurch.org",
+    siteName: "New Seoul Church",
+    type: "website",
+  },
+}
 
 export default function RootLayout({ children }: { children: ReactNode }) {
   return (

--- a/src/app/life-group/layout.tsx
+++ b/src/app/life-group/layout.tsx
@@ -1,0 +1,11 @@
+import { Metadata } from "next"
+import { ReactNode } from "react"
+
+export const metadata: Metadata = {
+  title: "Life Groups",
+  description: "Connect with others through Life Groups at New Seoul Church.",
+}
+
+export default function LifeGroupLayout({ children }: { children: ReactNode }) {
+  return <>{children}</>
+}

--- a/src/app/life-group/page.tsx
+++ b/src/app/life-group/page.tsx
@@ -58,15 +58,15 @@ export default function LifeGroupPage() {
     CARD_WIDTH
   );
   return (
-    <div className="px-4 sm:px-[55px]">
-      <section className="flex flex-col lg:flex-row items-center mt-[77px] py-[31px] gap-6">
+    <div className="px-4 sm:px-[85px]">
+      <section className="flex flex-col lg:flex-row items-center mt-[64px] sm:mt-[104px] py-[31px] gap-6">
         <div className="lg:w-1/2 lg:pr-6 w-full text-center lg:text-left">
-          <div className="text-3xl sm:text-4xl font-bold">LIFE GROUP</div>
-          <div className="mt-4 sm:mt-[19px] text-[18px] ">
+          <div className="text-[28px] sm:text-4xl font-bold uppercase">LIFE GROUP</div>
+          <div className="mt-4 sm:mt-[19px] text-base sm:text-[18px] leading-relaxed">
             At NSC, we gather after Sunday Service as a group through which we pray together, learn,
             grow in faith. We as a group aspire to be a witness of God’s presence.
           </div>
-          <div className="mt-4 sm:mt-[28px] text-[18px] ">
+          <div className="mt-4 sm:mt-[28px] text-base sm:text-[18px] leading-relaxed">
             We share our stories, along with fellowship, prayer times, reading scriptures, books.
           </div>
           <Link href="https://tinyurl.com/zw3whc2m" passHref>

--- a/src/app/page.tsx
+++ b/src/app/page.tsx
@@ -8,6 +8,12 @@ import Image from "next/image";
 import { EventCardList } from "@/components/EventCardList";
 import { collection, getDocs } from "firebase/firestore";
 import { fireStore } from "@/lib/firebase";
+
+function decodeHtml(str: string): string {
+  const txt = document.createElement("textarea");
+  txt.innerHTML = str;
+  return txt.value;
+}
 // import "./globals.css";
 
 type HomeVideoConfig = {
@@ -407,7 +413,7 @@ export default function Home() {
                           className="w-full h-[135px] rounded-md object-cover"
                         />
                         <p className="mt-2 text-sm font-medium text-gray-800 line-clamp-2">
-                          {data.title}
+                          {decodeHtml(data.title)}
                         </p>
                       </a>
                     </article>
@@ -467,7 +473,7 @@ export default function Home() {
                       height={"219px"}
                     />
                     <p className="mt-[10px] text-base font-medium">
-                      {data.title}
+                      {decodeHtml(data.title)}
                     </p>
                   </a>
                 </article>
@@ -526,7 +532,7 @@ export default function Home() {
                         />
                       </div>
                       <p className="mt-[10px] text-base font-medium">
-                        {data.title}
+                        {decodeHtml(data.title)}
                       </p>
                     </a>
                   </article>

--- a/src/app/robots.ts
+++ b/src/app/robots.ts
@@ -1,0 +1,8 @@
+import { MetadataRoute } from "next"
+
+export default function robots(): MetadataRoute.Robots {
+  return {
+    rules: [{ userAgent: "*", allow: "/", disallow: ["/admin", "/login"] }],
+    sitemap: "https://newseoulchurch.org/sitemap.xml",
+  }
+}

--- a/src/app/sermon/layout.tsx
+++ b/src/app/sermon/layout.tsx
@@ -1,0 +1,11 @@
+import { Metadata } from "next"
+import { ReactNode } from "react"
+
+export const metadata: Metadata = {
+  title: "Sermons",
+  description: "Watch and search sermons from New Seoul Church.",
+}
+
+export default function SermonLayout({ children }: { children: ReactNode }) {
+  return <>{children}</>
+}

--- a/src/app/sermon/page.tsx
+++ b/src/app/sermon/page.tsx
@@ -6,6 +6,12 @@ import { Button } from "@/components/ui/button";
 import { TYoutubeVideo } from "@/types/youtube";
 import React, { useEffect, useState } from "react";
 
+function decodeHtml(str: string): string {
+  const txt = document.createElement("textarea");
+  txt.innerHTML = str;
+  return txt.value;
+}
+
 export default function SermonSeriesPage() {
   const previousSermons = [
     {
@@ -74,16 +80,16 @@ export default function SermonSeriesPage() {
   return (
     <div className="bg-black text-white flex flex-col">
       <section
-        className="flex flex-col items-center sm:items-start justify-center mb-10 gap-4 px-6 sm:px-14 h-[351px] text-center sm:text-start"
+        className="flex flex-col items-center sm:items-start justify-center mb-10 gap-4 px-4 sm:px-[85px] h-[351px] text-center sm:text-start"
         style={{
           backgroundImage:
             "url('/assets/images/sermon/sermon-background-img.png')",
         }}
       >
-        <h1 className="text-3xl sm:text-4xl font-bold uppercase">
+        <h1 className="text-[28px] sm:text-4xl font-bold uppercase">
           Sermon Series
         </h1>
-        <div className="text-base max-w-2xl">
+        <div className="text-base sm:text-[18px] leading-relaxed max-w-2xl">
           Our Sermon Series offers a collection of thought-provoking teachings
           designed to deepen your faith and understanding in gospel.
         </div>
@@ -101,7 +107,7 @@ export default function SermonSeriesPage() {
         </Button>
       </section>
 
-      <section className="px-14 py-14">
+      <section className="px-4 sm:px-[85px] py-14">
         <div className="flex justify-center items-center">
           <h3 className="text-h3 font-bold">LATEST MESSAGE</h3>
         </div>
@@ -126,7 +132,7 @@ export default function SermonSeriesPage() {
                     height={"219px"}
                   />
                   <p className="mt-[10px] text-base font-medium">
-                    {data.title}
+                    {decodeHtml(data.title)}
                   </p>
                 </a>
               </article>
@@ -167,7 +173,7 @@ export default function SermonSeriesPage() {
           </div>
         )}
       </section> */}
-      <section className="flex flex-col items-center justify-center my-10 px-4 sm:px-14">
+      <section className="flex flex-col items-center justify-center my-10 px-4 sm:px-[85px]">
         <h1 className="text-xl sm:text-2xl font-bold uppercase text-center">
           Previous Sermons
         </h1>

--- a/src/app/sitemap.ts
+++ b/src/app/sitemap.ts
@@ -1,0 +1,22 @@
+import { MetadataRoute } from "next"
+
+export default function sitemap(): MetadataRoute.Sitemap {
+  const base = "https://newseoulchurch.org"
+  const routes = [
+    { path: "", priority: 1.0 },
+    { path: "/about", priority: 0.8 },
+    { path: "/beliefs", priority: 0.8 },
+    { path: "/sermon", priority: 0.8 },
+    { path: "/events", priority: 0.7 },
+    { path: "/visit", priority: 0.7 },
+    { path: "/life-group", priority: 0.7 },
+    { path: "/weekly-paper", priority: 0.6 },
+  ]
+
+  return routes.map(({ path, priority }) => ({
+    url: `${base}${path}`,
+    lastModified: new Date(),
+    changeFrequency: "weekly",
+    priority,
+  }))
+}

--- a/src/app/visit/layout.tsx
+++ b/src/app/visit/layout.tsx
@@ -1,0 +1,12 @@
+import { Metadata } from "next"
+import { ReactNode } from "react"
+
+export const metadata: Metadata = {
+  title: "Visit Us",
+  description:
+    "Service times, location, and directions for New Seoul Church in Seocho-gu, Seoul.",
+}
+
+export default function VisitLayout({ children }: { children: ReactNode }) {
+  return <>{children}</>
+}

--- a/src/app/visit/page.tsx
+++ b/src/app/visit/page.tsx
@@ -17,10 +17,10 @@ export default function VisitPage() {
 
   return (
     <div className="flex flex-col items-center w-full">
-      <div className="flex flex-col gap-8 px-4 sm:px-14 py-6 w-full max-w-[1024px]">
-        <div className="text-left text-2xl font-bold uppercase">Visit Us</div>
+      <div className="flex flex-col gap-8 px-4 sm:px-[85px] pt-[64px] sm:pt-[104px] pb-6 w-full max-w-[1024px]">
+        <div className="text-left text-[28px] sm:text-4xl font-bold uppercase">Visit Us</div>
 
-        <p className="text-left text-base sm:text-lg leading-relaxed">
+        <p className="text-left text-base sm:text-[18px] leading-relaxed">
           Whether you are new to faith or seeking a church home, we invite you
           to join us and be part of a Christ-centered community committed to
           spiritual growth and service.
@@ -46,12 +46,12 @@ export default function VisitPage() {
         />
       </div>
 
-      <div className="w-full max-w-[1024px] px-4 sm:px-14">
+      <div className="w-full max-w-[1024px] px-4 sm:px-[85px]">
         <OurServices />
       </div>
 
-      <div className="flex flex-col gap-9 px-4 sm:px-14 py-6 w-full max-w-[1024px]">
-        <div className="text-left text-2xl font-bold uppercase">Location</div>
+      <div className="flex flex-col gap-9 px-4 sm:px-[85px] py-6 w-full max-w-[1024px]">
+        <div className="text-left text-2xl sm:text-3xl font-bold uppercase">Location</div>
 
         <div className="w-full h-[375px] rounded-lg overflow-hidden">
           <iframe

--- a/src/app/weekly-paper/layout.tsx
+++ b/src/app/weekly-paper/layout.tsx
@@ -1,0 +1,11 @@
+import { Metadata } from "next"
+import { ReactNode } from "react"
+
+export const metadata: Metadata = {
+  title: "Weekly Paper",
+  description: "Weekly bulletins from New Seoul Church.",
+}
+
+export default function WeeklyPaperLayout({ children }: { children: ReactNode }) {
+  return <>{children}</>
+}

--- a/src/app/weekly-paper/page.tsx
+++ b/src/app/weekly-paper/page.tsx
@@ -18,7 +18,7 @@ export default function WeeklyPage() {
 
   return (
     <>
-      <section className="py-[16px] px-4 sm:px-[54px]">
+      <section className="py-[16px] px-4 sm:px-[85px] mt-[64px] sm:mt-[104px]">
         <div className="w-full  rounded-[12px] overflow-hidden">
           <div className="flex flex-col items-center justify-center text-center gap-6 py-6">
             {isLoading ? (

--- a/src/components/PageHeader.tsx
+++ b/src/components/PageHeader.tsx
@@ -1,0 +1,9 @@
+export function PageHeader({ title }: { title: string }) {
+  return (
+    <section className="h-[300px] sm:h-[436px] flex justify-center items-center px-4">
+      <h1 className="text-[28px] sm:text-4xl font-bold uppercase text-center">
+        {title}
+      </h1>
+    </section>
+  )
+}

--- a/src/components/layout/Footer.tsx
+++ b/src/components/layout/Footer.tsx
@@ -89,6 +89,16 @@ export default function Footer() {
           ))}
         </div>
       </div>
+      <div className="flex justify-end mt-8">
+        <div className="flex flex-col text-center md:text-right">
+          <div className="text-white font-bold mb-2">OFFERING</div>
+          <div className="flex flex-col gap-1 text-sm text-white">
+            <span>Sunday Offering — 국민 782701-04-139438 (뉴서울교회)</span>
+            <span>Next Gen Support — 우리 1002863857531 (뉴서울교회)</span>
+          </div>
+        </div>
+      </div>
+
       <div className="flex w-full flex-col items-center gap-2 md:flex-row md:items-center md:justify-between">
         <div className="mt-[60px] text-white leading-[100%] text-sm">@NSC</div>
         <div className="mt-[60px] text-white leading-[100%] text-sm text-right">

--- a/src/components/layout/Footer.tsx
+++ b/src/components/layout/Footer.tsx
@@ -44,6 +44,10 @@ export default function Footer() {
           title: "INSTAGRAM",
           url: "https://www.instagram.com/nsc_newseoulchurch/",
         },
+        {
+          title: "TIKTOK",
+          url: "https://www.tiktok.com/@new.seoul.church",
+        },
       ],
     },
   ];
@@ -87,8 +91,9 @@ export default function Footer() {
       </div>
       <div className="flex w-full flex-col items-center gap-2 md:flex-row md:items-center md:justify-between">
         <div className="mt-[60px] text-white leading-[100%] text-sm">@NSC</div>
-        <div className="mt-[60px] text-white leading-[100%] text-sm">
-          New Seoul Church 010-2380-9189
+        <div className="mt-[60px] text-white leading-[100%] text-sm text-right">
+          <div>A Presbyterian church in Seoul</div>
+          <div className="mt-1">New Seoul Church 010-2380-9189</div>
         </div>
       </div>
     </footer>

--- a/src/components/layout/Footer.tsx
+++ b/src/components/layout/Footer.tsx
@@ -88,7 +88,7 @@ export default function Footer() {
       <div className="flex w-full flex-col items-center gap-2 md:flex-row md:items-center md:justify-between">
         <div className="mt-[60px] text-white leading-[100%] text-sm">@NSC</div>
         <div className="mt-[60px] text-white leading-[100%] text-sm">
-          Senior pastor Joe Oh 010-2380-9189
+          New Seoul Church 010-2380-9189
         </div>
       </div>
     </footer>


### PR DESCRIPTION
## Summary
- Add SEO metadata, sitemap.xml, and robots.txt across all public pages
- Fix sermon ingest: transcript truncation, 1 video per run, null embedding guard
- Footer: update phone label, add Presbyterian identity, add TikTok link
- Fix iOS PDF rendering on Beliefs page

## Test plan
- [ ] Verify page titles show correctly in browser tab for each route
- [ ] Check /sitemap.xml and /robots.txt render correctly
- [ ] Confirm footer shows "A Presbyterian church in Seoul" and TikTok link on all pages
- [ ] Verify sermon ingest runs cleanly on next Tuesday cron