### PR TITLE
Fix sermon ingest OpenAI token limit

### DIFF
--- a/src/app/api/sermon/ingest/route.ts
+++ b/src/app/api/sermon/ingest/route.ts
@@ -62,8 +62,8 @@ async function fetchTranscript(videoId: string) {
   return json.content;
 }
 
-// text-embedding-3-large limit is 8191 tokens (~32k chars); truncate to stay safe
-const MAX_EMBEDDING_CHARS = 25000;
+// text-embedding-3-large hard limit is 8191 tokens; 16k chars ~= 7k tokens in practice
+const MAX_EMBEDDING_CHARS = 16000;
 
 // Helper: Get OpenAI embedding
 async function getEmbedding(text: string) {


### PR DESCRIPTION
## Summary
- Reduced `MAX_EMBEDDING_CHARS` from 25,000 to 16,000 characters
- The old limit could exceed OpenAI's hard 8,191-token limit for `text-embedding-3-large`, causing ingest failures with a 400 error
- 16,000 chars ≈ 7,088 tokens in practice, safely within the limit

## Test plan
- [x] Manually ingested May 12 sermon (`dAX5vq-XhpI`) with the new limit — succeeded (7,088 tokens, 3,072-dim embedding inserted)
- [ ] Verify thumbnail loads on production after merge