### PR TITLE
Add period to end of parking area description

### DIFF
--- a/src/app/visit/parking-info.tsx
+++ b/src/app/visit/parking-info.tsx
@@ -8,7 +8,7 @@ export default function ParkingInfo() {
       <div className="text-left flex flex-col gap-4 text-lg w-full md:w-[735px]">
         An outdoor parking lot is located at the right side of the church. The
         indoor parking entrance is located at the left side of the church, which
-        leads to B2 and B3 floor
+        leads to B2 and B3 floor.
       </div>
     </div>
   )


### PR DESCRIPTION
## Summary
- Adds a missing period to the end of the Parking Area description on the Visit page (`src/app/visit/parking-info.tsx`).

## Test plan
- [ ] Visit `/visit` and confirm the parking area text ends with a period: "...which leads to B2 and B3 floor."

https://claude.ai/code/session_01NfoeVRYrwsMtvYR1t4pCws

---
_Generated by [Claude Code](https://claude.ai/code/session_01NfoeVRYrwsMtvYR1t4pCws)_