### PR TITLE
feat: announcement bulletin board

### DIFF
--- a/src/app/admin/bulletin/page.tsx
+++ b/src/app/admin/bulletin/page.tsx
@@ -1,17 +1,20 @@
+import { createClient } from "@supabase/supabase-js"
 import { cookies } from "next/headers"
 import { redirect } from "next/navigation"
 import BulletinBoard from "@/components/bulletin/BulletinBoard"
 import type { BulletinItem } from "@/types/bulletin"
 
 async function getItems(): Promise<BulletinItem[]> {
-  const base = process.env.VERCEL_URL
-    ? `https://${process.env.VERCEL_URL}`
-    : (process.env.NEXT_PUBLIC_SITE_URL ?? "http://localhost:3000")
-  const res = await fetch(`${base}/api/bulletin/layout`, {
-    cache: "no-store",
-  })
-  if (!res.ok) return []
-  return res.json()
+  const { data, error } = await createClient(
+    process.env.SUPABASE_URL!,
+    process.env.SUPABASE_SERVICE_ROLE_KEY!
+  )
+    .from("bulletin_items")
+    .select("*")
+    .order("created_at", { ascending: true })
+
+  if (error) return []
+  return data
 }
 
 export default async function AdminBulletinPage() {

--- a/src/app/admin/bulletin/page.tsx
+++ b/src/app/admin/bulletin/page.tsx
@@ -4,8 +4,9 @@ import BulletinBoard from "@/components/bulletin/BulletinBoard"
 import type { BulletinItem } from "@/types/bulletin"
 
 async function getItems(): Promise<BulletinItem[]> {
-  const base = process.env.NEXT_PUBLIC_SITE_URL
-    ?? (process.env.VERCEL_URL ? `https://${process.env.VERCEL_URL}` : "http://localhost:3000")
+  const base = process.env.VERCEL_URL
+    ? `https://${process.env.VERCEL_URL}`
+    : (process.env.NEXT_PUBLIC_SITE_URL ?? "http://localhost:3000")
   const res = await fetch(`${base}/api/bulletin/layout`, {
     cache: "no-store",
   })

--- a/src/app/admin/bulletin/page.tsx
+++ b/src/app/admin/bulletin/page.tsx
@@ -4,7 +4,9 @@ import BulletinBoard from "@/components/bulletin/BulletinBoard"
 import type { BulletinItem } from "@/types/bulletin"
 
 async function getItems(): Promise<BulletinItem[]> {
-  const res = await fetch(`${process.env.NEXT_PUBLIC_SITE_URL ?? "http://localhost:3000"}/api/bulletin/layout`, {
+  const base = process.env.NEXT_PUBLIC_SITE_URL
+    ?? (process.env.VERCEL_URL ? `https://${process.env.VERCEL_URL}` : "http://localhost:3000")
+  const res = await fetch(`${base}/api/bulletin/layout`, {
     cache: "no-store",
   })
   if (!res.ok) return []

--- a/src/app/admin/bulletin/page.tsx
+++ b/src/app/admin/bulletin/page.tsx
@@ -1,0 +1,25 @@
+import { cookies } from "next/headers"
+import { redirect } from "next/navigation"
+import BulletinBoard from "@/components/bulletin/BulletinBoard"
+import type { BulletinItem } from "@/types/bulletin"
+
+async function getItems(): Promise<BulletinItem[]> {
+  const res = await fetch(`${process.env.NEXT_PUBLIC_SITE_URL ?? "http://localhost:3000"}/api/bulletin/layout`, {
+    cache: "no-store",
+  })
+  if (!res.ok) return []
+  return res.json()
+}
+
+export default async function AdminBulletinPage() {
+  const cookieStore = await cookies()
+  if (!cookieStore.get("adminToken")?.value) redirect("/login")
+
+  const items = await getItems()
+
+  return (
+    <div className="w-full">
+      <BulletinBoard initialItems={items} mode="edit" />
+    </div>
+  )
+}

--- a/src/app/admin/layout.tsx
+++ b/src/app/admin/layout.tsx
@@ -8,7 +8,7 @@ export default async function AdminLayout({
 }: {
   children: ReactNode;
 }) {
-  const cookieStore = cookies(); // await 필요 없음
+  const cookieStore = await cookies();
   const token = cookieStore.get("adminToken")?.value;
   console.log("//token", token);
   if (!token) {

--- a/src/app/admin/page.tsx
+++ b/src/app/admin/page.tsx
@@ -23,6 +23,9 @@ export default async function AdminPage() {
         <a href="/admin/home-video" className="underline text-blue-500">
           홈 화면 영상 설정
         </a>
+        <a href="/admin/bulletin" className="underline text-blue-500">
+          게시판 관리
+        </a>
       </div>
     </div>
   );

--- a/src/app/api/bulletin/delete/[id]/route.ts
+++ b/src/app/api/bulletin/delete/[id]/route.ts
@@ -1,0 +1,37 @@
+import { del } from "@vercel/blob"
+import { createClient } from "@supabase/supabase-js"
+import { NextResponse } from "next/server"
+import { cookies } from "next/headers"
+
+function supabase() {
+  return createClient(
+    process.env.SUPABASE_URL!,
+    process.env.SUPABASE_SERVICE_ROLE_KEY!
+  )
+}
+
+export async function DELETE(
+  _request: Request,
+  { params }: { params: Promise<{ id: string }> }
+) {
+  const cookieStore = await cookies()
+  if (!cookieStore.get("adminToken")?.value) {
+    return NextResponse.json({ error: "Unauthorized" }, { status: 401 })
+  }
+
+  const { id } = await params
+  const db = supabase()
+
+  const { data, error } = await db
+    .from("bulletin_items")
+    .delete()
+    .eq("id", id)
+    .select("image_url")
+    .single()
+
+  if (error) return NextResponse.json({ error: error.message }, { status: 500 })
+
+  await del(data.image_url)
+
+  return NextResponse.json({ ok: true })
+}

--- a/src/app/api/bulletin/delete/[id]/route.ts
+++ b/src/app/api/bulletin/delete/[id]/route.ts
@@ -20,6 +20,10 @@ export async function DELETE(
   }
 
   const { id } = await params
+  const UUID_RE = /^[0-9a-f]{8}-[0-9a-f]{4}-[0-9a-f]{4}-[0-9a-f]{4}-[0-9a-f]{12}$/i
+  if (!UUID_RE.test(id)) {
+    return NextResponse.json({ error: "Invalid id" }, { status: 400 })
+  }
   const db = supabase()
 
   const { data, error } = await db
@@ -31,7 +35,7 @@ export async function DELETE(
 
   if (error) return NextResponse.json({ error: error.message }, { status: 500 })
 
-  await del(data.image_url)
+  if (data?.image_url) await del(data.image_url)
 
   return NextResponse.json({ ok: true })
 }

--- a/src/app/api/bulletin/layout/route.ts
+++ b/src/app/api/bulletin/layout/route.ts
@@ -27,11 +27,16 @@ export async function POST(request: Request) {
   }
 
   const items: BulletinItem[] = await request.json()
+  if (!Array.isArray(items)) {
+    return NextResponse.json({ error: "Invalid payload" }, { status: 400 })
+  }
   const db = supabase()
 
   const { error: deleteError } = await db.from("bulletin_items").delete().neq("id", "00000000-0000-0000-0000-000000000000")
   if (deleteError) return NextResponse.json({ error: deleteError.message }, { status: 500 })
 
+  // Note: delete is already committed; insert failure leaves the board empty.
+  // Acceptable trade-off for this feature's scale.
   if (items.length > 0) {
     const { error: insertError } = await db.from("bulletin_items").insert(
       items.map(({ id, image_url, x, y, width, height, rotation, z_index, created_at }) => ({

--- a/src/app/api/bulletin/layout/route.ts
+++ b/src/app/api/bulletin/layout/route.ts
@@ -1,0 +1,45 @@
+import { createClient } from "@supabase/supabase-js"
+import { NextResponse } from "next/server"
+import { cookies } from "next/headers"
+import type { BulletinItem } from "@/types/bulletin"
+
+function supabase() {
+  return createClient(
+    process.env.SUPABASE_URL!,
+    process.env.SUPABASE_SERVICE_ROLE_KEY!
+  )
+}
+
+export async function GET() {
+  const { data, error } = await supabase()
+    .from("bulletin_items")
+    .select("*")
+    .order("created_at", { ascending: true })
+
+  if (error) return NextResponse.json({ error: error.message }, { status: 500 })
+  return NextResponse.json(data)
+}
+
+export async function POST(request: Request) {
+  const cookieStore = await cookies()
+  if (!cookieStore.get("adminToken")?.value) {
+    return NextResponse.json({ error: "Unauthorized" }, { status: 401 })
+  }
+
+  const items: BulletinItem[] = await request.json()
+  const db = supabase()
+
+  const { error: deleteError } = await db.from("bulletin_items").delete().neq("id", "00000000-0000-0000-0000-000000000000")
+  if (deleteError) return NextResponse.json({ error: deleteError.message }, { status: 500 })
+
+  if (items.length > 0) {
+    const { error: insertError } = await db.from("bulletin_items").insert(
+      items.map(({ id, image_url, x, y, width, height, rotation, z_index, created_at }) => ({
+        id, image_url, x, y, width, height, rotation, z_index, created_at,
+      }))
+    )
+    if (insertError) return NextResponse.json({ error: insertError.message }, { status: 500 })
+  }
+
+  return NextResponse.json({ ok: true })
+}

--- a/src/app/api/bulletin/upload/route.ts
+++ b/src/app/api/bulletin/upload/route.ts
@@ -1,0 +1,59 @@
+import { put } from "@vercel/blob"
+import { createClient } from "@supabase/supabase-js"
+import { NextResponse } from "next/server"
+import { cookies } from "next/headers"
+
+function supabase() {
+  return createClient(
+    process.env.SUPABASE_URL!,
+    process.env.SUPABASE_SERVICE_ROLE_KEY!
+  )
+}
+
+const MAX_BYTES = 10 * 1024 * 1024 // 10MB
+const CANVAS_W = 1200
+const CANVAS_H = 800
+const DEFAULT_W = 220
+const DEFAULT_H = 280
+
+export async function POST(request: Request) {
+  const cookieStore = await cookies()
+  if (!cookieStore.get("adminToken")?.value) {
+    return NextResponse.json({ error: "Unauthorized" }, { status: 401 })
+  }
+
+  const formData = await request.formData()
+  const file = formData.get("file")
+
+  if (!(file instanceof File)) {
+    return NextResponse.json({ error: "No file provided" }, { status: 400 })
+  }
+  if (file.size > MAX_BYTES) {
+    return NextResponse.json({ error: "File exceeds 10MB limit" }, { status: 400 })
+  }
+
+  const db = supabase()
+  const { count } = await db.from("bulletin_items").select("id", { count: "exact", head: true })
+  if ((count ?? 0) >= 15) {
+    return NextResponse.json({ error: "Board is full (max 15 items)" }, { status: 400 })
+  }
+
+  const safeName = file.name.replace(/[^a-zA-Z0-9._-]/g, "_")
+  const blob = await put(`bulletin/${Date.now()}-${safeName}`, file, {
+    access: "public",
+    addRandomSuffix: false,
+  })
+
+  const rotation = Math.random() * 8 - 4
+  const x = Math.round(CANVAS_W / 2 - DEFAULT_W / 2)
+  const y = Math.round(CANVAS_H / 2 - DEFAULT_H / 2)
+
+  const { data, error } = await db
+    .from("bulletin_items")
+    .insert({ image_url: blob.url, x, y, width: DEFAULT_W, height: DEFAULT_H, rotation, z_index: count ?? 0 })
+    .select()
+    .single()
+
+  if (error) return NextResponse.json({ error: error.message }, { status: 500 })
+  return NextResponse.json(data)
+}

--- a/src/app/bulletin/page.tsx
+++ b/src/app/bulletin/page.tsx
@@ -2,8 +2,9 @@ import BulletinBoard from "@/components/bulletin/BulletinBoard"
 import type { BulletinItem } from "@/types/bulletin"
 
 async function getItems(): Promise<BulletinItem[]> {
-  const base = process.env.NEXT_PUBLIC_SITE_URL
-    ?? (process.env.VERCEL_URL ? `https://${process.env.VERCEL_URL}` : "http://localhost:3000")
+  const base = process.env.VERCEL_URL
+    ? `https://${process.env.VERCEL_URL}`
+    : (process.env.NEXT_PUBLIC_SITE_URL ?? "http://localhost:3000")
   const res = await fetch(`${base}/api/bulletin/layout`, {
     cache: "no-store",
   })

--- a/src/app/bulletin/page.tsx
+++ b/src/app/bulletin/page.tsx
@@ -1,0 +1,24 @@
+import BulletinBoard from "@/components/bulletin/BulletinBoard"
+import type { BulletinItem } from "@/types/bulletin"
+
+async function getItems(): Promise<BulletinItem[]> {
+  const res = await fetch(`${process.env.NEXT_PUBLIC_SITE_URL ?? "http://localhost:3000"}/api/bulletin/layout`, {
+    cache: "no-store",
+  })
+  if (!res.ok) return []
+  return res.json()
+}
+
+export default async function BulletinPage() {
+  const items = await getItems()
+
+  return (
+    <div className="w-full">
+      <div className="px-4 sm:px-[85px] py-8">
+        <h1 className="text-2xl font-bold tracking-widest uppercase mb-1">Announcements</h1>
+        <p className="text-sm text-gray-500 mb-6">Click any poster to view full size</p>
+      </div>
+      <BulletinBoard initialItems={items} mode="view" />
+    </div>
+  )
+}

--- a/src/app/bulletin/page.tsx
+++ b/src/app/bulletin/page.tsx
@@ -1,15 +1,18 @@
+import { createClient } from "@supabase/supabase-js"
 import BulletinBoard from "@/components/bulletin/BulletinBoard"
 import type { BulletinItem } from "@/types/bulletin"
 
 async function getItems(): Promise<BulletinItem[]> {
-  const base = process.env.VERCEL_URL
-    ? `https://${process.env.VERCEL_URL}`
-    : (process.env.NEXT_PUBLIC_SITE_URL ?? "http://localhost:3000")
-  const res = await fetch(`${base}/api/bulletin/layout`, {
-    cache: "no-store",
-  })
-  if (!res.ok) return []
-  return res.json()
+  const { data, error } = await createClient(
+    process.env.SUPABASE_URL!,
+    process.env.SUPABASE_SERVICE_ROLE_KEY!
+  )
+    .from("bulletin_items")
+    .select("*")
+    .order("created_at", { ascending: true })
+
+  if (error) return []
+  return data
 }
 
 export default async function BulletinPage() {

--- a/src/app/bulletin/page.tsx
+++ b/src/app/bulletin/page.tsx
@@ -1,5 +1,7 @@
 import { createClient } from "@supabase/supabase-js"
 import BulletinBoard from "@/components/bulletin/BulletinBoard"
+
+export const dynamic = "force-dynamic"
 import type { BulletinItem } from "@/types/bulletin"
 
 async function getItems(): Promise<BulletinItem[]> {

--- a/src/app/bulletin/page.tsx
+++ b/src/app/bulletin/page.tsx
@@ -2,7 +2,9 @@ import BulletinBoard from "@/components/bulletin/BulletinBoard"
 import type { BulletinItem } from "@/types/bulletin"
 
 async function getItems(): Promise<BulletinItem[]> {
-  const res = await fetch(`${process.env.NEXT_PUBLIC_SITE_URL ?? "http://localhost:3000"}/api/bulletin/layout`, {
+  const base = process.env.NEXT_PUBLIC_SITE_URL
+    ?? (process.env.VERCEL_URL ? `https://${process.env.VERCEL_URL}` : "http://localhost:3000")
+  const res = await fetch(`${base}/api/bulletin/layout`, {
     cache: "no-store",
   })
   if (!res.ok) return []

--- a/src/app/bulletin/page.tsx
+++ b/src/app/bulletin/page.tsx
@@ -13,12 +13,14 @@ export default async function BulletinPage() {
   const items = await getItems()
 
   return (
-    <div className="w-full">
-      <div className="px-4 sm:px-[85px] py-8">
-        <h1 className="text-2xl font-bold tracking-widest uppercase mb-1">Announcements</h1>
-        <p className="text-sm text-gray-500 mb-6">Click any poster to view full size</p>
+    <div className="w-full pb-20">
+      <div className="px-4 sm:px-8 pt-8 pb-5">
+        <h1 className="text-2xl font-semibold tracking-widest uppercase mb-3">Announcements</h1>
+        <p className="text-xs text-gray-400 tracking-widest uppercase">Current announcements</p>
       </div>
-      <BulletinBoard initialItems={items} mode="view" />
+      <div className="px-4 sm:px-8">
+        <BulletinBoard initialItems={items} mode="view" />
+      </div>
     </div>
   )
 }

--- a/src/components/bulletin/BulletinBoard.tsx
+++ b/src/components/bulletin/BulletinBoard.tsx
@@ -1,0 +1,226 @@
+"use client"
+
+import { useState, useRef, useCallback, useEffect } from "react"
+import type { BulletinItem as Item } from "@/types/bulletin"
+import BulletinItemComp from "./BulletinItem"
+import BulletinLightbox from "./BulletinLightbox"
+import BulletinToolbar from "./BulletinToolbar"
+
+const CANVAS_W = 1200
+const CANVAS_H = 800
+
+type Props = {
+  initialItems: Item[]
+  mode: "view" | "edit"
+}
+
+type DragState = {
+  type: "drag" | "resize"
+  itemId: string
+  startPointerX: number
+  startPointerY: number
+  startItemX: number
+  startItemY: number
+  startItemW: number
+  startItemH: number
+}
+
+export default function BulletinBoard({ initialItems, mode }: Props) {
+  const [items, setItems] = useState<Item[]>(initialItems)
+  const [selectedId, setSelectedId] = useState<string | null>(null)
+  const [lightboxUrl, setLightboxUrl] = useState<string | null>(null)
+  const [saving, setSaving] = useState(false)
+  const containerRef = useRef<HTMLDivElement>(null)
+  const dragRef = useRef<DragState | null>(null)
+
+  const [scale, setScale] = useState(1)
+  useEffect(() => {
+    function updateScale() {
+      if (containerRef.current) {
+        setScale(containerRef.current.clientWidth / CANVAS_W)
+      }
+    }
+    updateScale()
+    window.addEventListener("resize", updateScale)
+    return () => window.removeEventListener("resize", updateScale)
+  }, [])
+
+  function handleCanvasClick(e: React.MouseEvent) {
+    if (e.target === e.currentTarget) setSelectedId(null)
+  }
+
+  const handlePointerMove = useCallback((e: PointerEvent) => {
+    const drag = dragRef.current
+    if (!drag) return
+    const currentScale = containerRef.current
+      ? containerRef.current.clientWidth / CANVAS_W
+      : 1
+    const dx = (e.clientX - drag.startPointerX) / currentScale
+    const dy = (e.clientY - drag.startPointerY) / currentScale
+
+    setItems((prev) =>
+      prev.map((item) => {
+        if (item.id !== drag.itemId) return item
+        if (drag.type === "drag") {
+          return { ...item, x: Math.round(drag.startItemX + dx), y: Math.round(drag.startItemY + dy) }
+        } else {
+          return {
+            ...item,
+            width: Math.max(80, Math.round(drag.startItemW + dx)),
+            height: Math.max(80, Math.round(drag.startItemH + dy)),
+          }
+        }
+      })
+    )
+  }, [])
+
+  const handlePointerUp = useCallback(() => {
+    dragRef.current = null
+    window.removeEventListener("pointermove", handlePointerMove)
+    window.removeEventListener("pointerup", handlePointerUp)
+  }, [handlePointerMove])
+
+  function startDrag(e: React.PointerEvent, item: Item, type: "drag" | "resize") {
+    e.preventDefault()
+    dragRef.current = {
+      type,
+      itemId: item.id,
+      startPointerX: e.clientX,
+      startPointerY: e.clientY,
+      startItemX: item.x,
+      startItemY: item.y,
+      startItemW: item.width,
+      startItemH: item.height,
+    }
+    window.addEventListener("pointermove", handlePointerMove)
+    window.addEventListener("pointerup", handlePointerUp)
+  }
+
+  async function handleUpload(file: File) {
+    const formData = new FormData()
+    formData.append("file", file)
+    const res = await fetch("/api/bulletin/upload", { method: "POST", body: formData })
+    if (!res.ok) {
+      const { error } = await res.json()
+      alert(error)
+      return
+    }
+    const newItem: Item = await res.json()
+    setItems((prev) => [...prev, newItem])
+  }
+
+  async function handleDelete(id: string) {
+    const res = await fetch(`/api/bulletin/delete/${id}`, { method: "DELETE" })
+    if (!res.ok) return
+    setItems((prev) => prev.filter((i) => i.id !== id))
+    setSelectedId(null)
+  }
+
+  async function handleSave() {
+    setSaving(true)
+    await fetch("/api/bulletin/layout", {
+      method: "POST",
+      headers: { "Content-Type": "application/json" },
+      body: JSON.stringify(items),
+    })
+    setSaving(false)
+  }
+
+  return (
+    <div className="w-full">
+      {mode === "edit" && (
+        <BulletinToolbar
+          itemCount={items.length}
+          saving={saving}
+          onUpload={handleUpload}
+          onSave={handleSave}
+        />
+      )}
+
+      {/* Desktop: scaled canvas */}
+      <div ref={containerRef} className="hidden md:block w-full" style={{ height: CANVAS_H * scale }}>
+        <div
+          style={{
+            width: CANVAS_W,
+            height: CANVAS_H,
+            transformOrigin: "top left",
+            transform: `scale(${scale})`,
+            position: "relative",
+            background: "#c4a06a",
+            backgroundImage:
+              "repeating-linear-gradient(45deg, #8b6914 0, #8b6914 1px, transparent 0, transparent 50%)",
+            backgroundSize: "6px 6px",
+          }}
+          onClick={handleCanvasClick}
+        >
+          <div
+            style={{
+              position: "absolute",
+              inset: 0,
+              opacity: 0.22,
+              backgroundImage:
+                "repeating-linear-gradient(45deg, #8b6914 0, #8b6914 1px, transparent 0, transparent 50%)",
+              backgroundSize: "6px 6px",
+              pointerEvents: "none",
+            }}
+          />
+          {items.map((item) => (
+            <BulletinItemComp
+              key={item.id}
+              item={item}
+              mode={mode}
+              selected={selectedId === item.id}
+              onSelect={() => setSelectedId(item.id)}
+              onDelete={() => handleDelete(item.id)}
+              onDragStart={(e) => startDrag(e, item, "drag")}
+              onResizeStart={(e) => startDrag(e, item, "resize")}
+              onViewClick={() => setLightboxUrl(item.image_url)}
+            />
+          ))}
+        </div>
+      </div>
+
+      {/* Mobile: 2-column grid */}
+      <div
+        className="md:hidden w-full p-4"
+        style={{
+          background: "#c4a06a",
+          backgroundImage:
+            "repeating-linear-gradient(45deg, #8b6914 0, #8b6914 1px, transparent 0, transparent 50%)",
+          backgroundSize: "6px 6px",
+          minHeight: 300,
+        }}
+      >
+        <div className="grid grid-cols-2 gap-4">
+          {[...items]
+            .sort((a, b) => new Date(a.created_at).getTime() - new Date(b.created_at).getTime())
+            .map((item) => (
+              <div
+                key={item.id}
+                style={{
+                  transform: `rotate(${item.rotation}deg)`,
+                  boxShadow: "4px 6px 16px rgba(0,0,0,0.45)",
+                  borderRadius: 2,
+                  overflow: "hidden",
+                  aspectRatio: "3/4",
+                  cursor: "pointer",
+                }}
+                onClick={() => setLightboxUrl(item.image_url)}
+              >
+                {/* eslint-disable-next-line @next/next/no-img-element */}
+                <img
+                  src={item.image_url}
+                  alt="Announcement"
+                  style={{ width: "100%", height: "100%", objectFit: "cover", display: "block" }}
+                />
+              </div>
+            ))}
+        </div>
+      </div>
+
+      {lightboxUrl && (
+        <BulletinLightbox imageUrl={lightboxUrl} onClose={() => setLightboxUrl(null)} />
+      )}
+    </div>
+  )
+}

--- a/src/components/bulletin/BulletinBoard.tsx
+++ b/src/components/bulletin/BulletinBoard.tsx
@@ -134,7 +134,20 @@ export default function BulletinBoard({ initialItems, mode }: Props) {
       return
     }
     const newItem: Item = await res.json()
-    setItems((prev) => [...prev, newItem])
+
+    const url = URL.createObjectURL(file)
+    const img = new window.Image()
+    img.onload = () => {
+      URL.revokeObjectURL(url)
+      const MAX_W = 260, MAX_H = 340
+      const ratio = img.naturalWidth / img.naturalHeight
+      let w = MAX_W
+      let h = Math.round(w / ratio)
+      if (h > MAX_H) { h = MAX_H; w = Math.round(h * ratio) }
+      setItems((prev) => [...prev, { ...newItem, width: w, height: h }])
+    }
+    img.onerror = () => { URL.revokeObjectURL(url); setItems((prev) => [...prev, newItem]) }
+    img.src = url
   }
 
   async function handleDelete(id: string) {

--- a/src/components/bulletin/BulletinBoard.tsx
+++ b/src/components/bulletin/BulletinBoard.tsx
@@ -118,12 +118,16 @@ export default function BulletinBoard({ initialItems, mode }: Props) {
 
   async function handleSave() {
     setSaving(true)
-    await fetch("/api/bulletin/layout", {
+    const res = await fetch("/api/bulletin/layout", {
       method: "POST",
       headers: { "Content-Type": "application/json" },
       body: JSON.stringify(items),
     })
     setSaving(false)
+    if (!res.ok) {
+      const { error } = await res.json().catch(() => ({ error: "Save failed" }))
+      alert(error ?? "Save failed")
+    }
   }
 
   return (

--- a/src/components/bulletin/BulletinBoard.tsx
+++ b/src/components/bulletin/BulletinBoard.tsx
@@ -15,7 +15,7 @@ type Props = {
 }
 
 type DragState = {
-  type: "drag" | "resize"
+  type: "drag" | "resize" | "resize-h" | "resize-v" | "rotate"
   itemId: string
   startPointerX: number
   startPointerY: number
@@ -23,6 +23,10 @@ type DragState = {
   startItemY: number
   startItemW: number
   startItemH: number
+  aspectRatio?: number
+  centerViewportX?: number
+  centerViewportY?: number
+  startRotation?: number
 }
 
 export default function BulletinBoard({ initialItems, mode }: Props) {
@@ -30,6 +34,7 @@ export default function BulletinBoard({ initialItems, mode }: Props) {
   const [selectedId, setSelectedId] = useState<string | null>(null)
   const [lightboxUrl, setLightboxUrl] = useState<string | null>(null)
   const [saving, setSaving] = useState(false)
+  const [lightboxOrigin, setLightboxOrigin] = useState<{ x: number; y: number; width: number; height: number } | null>(null)
   const containerRef = useRef<HTMLDivElement>(null)
   const dragRef = useRef<DragState | null>(null)
 
@@ -63,13 +68,27 @@ export default function BulletinBoard({ initialItems, mode }: Props) {
         if (item.id !== drag.itemId) return item
         if (drag.type === "drag") {
           return { ...item, x: Math.round(drag.startItemX + dx), y: Math.round(drag.startItemY + dy) }
-        } else {
-          return {
-            ...item,
-            width: Math.max(80, Math.round(drag.startItemW + dx)),
-            height: Math.max(80, Math.round(drag.startItemH + dy)),
-          }
         }
+        if (drag.type === "resize") {
+          const newW = Math.max(80, Math.round(drag.startItemW + dx))
+          const newH = Math.max(80, Math.round(newW / drag.aspectRatio!))
+          return { ...item, width: newW, height: newH }
+        }
+        if (drag.type === "resize-h") {
+          return { ...item, width: Math.max(80, Math.round(drag.startItemW + dx)) }
+        }
+        if (drag.type === "resize-v") {
+          return { ...item, height: Math.max(80, Math.round(drag.startItemH + dy)) }
+        }
+        if (drag.type === "rotate") {
+          const cx = drag.centerViewportX!
+          const cy = drag.centerViewportY!
+          const startAngle = Math.atan2(drag.startPointerY - cy, drag.startPointerX - cx)
+          const currentAngle = Math.atan2(e.clientY - cy, e.clientX - cx)
+          const delta = (currentAngle - startAngle) * (180 / Math.PI)
+          return { ...item, rotation: Math.round(drag.startRotation! + delta) }
+        }
+        return item
       })
     )
   }, [])
@@ -80,8 +99,11 @@ export default function BulletinBoard({ initialItems, mode }: Props) {
     window.removeEventListener("pointerup", handlePointerUp)
   }, [handlePointerMove])
 
-  function startDrag(e: React.PointerEvent, item: Item, type: "drag" | "resize") {
+  function startDrag(e: React.PointerEvent, item: Item, type: DragState["type"]) {
     e.preventDefault()
+    const container = containerRef.current
+    const currentScale = container ? container.clientWidth / CANVAS_W : 1
+    const canvasRect = container?.getBoundingClientRect()
     dragRef.current = {
       type,
       itemId: item.id,
@@ -91,6 +113,12 @@ export default function BulletinBoard({ initialItems, mode }: Props) {
       startItemY: item.y,
       startItemW: item.width,
       startItemH: item.height,
+      ...(type === "resize" && { aspectRatio: item.width / item.height }),
+      ...(type === "rotate" && canvasRect && {
+        centerViewportX: canvasRect.left + (item.x + item.width / 2) * currentScale,
+        centerViewportY: canvasRect.top + (item.y + item.height / 2) * currentScale,
+        startRotation: item.rotation,
+      }),
     }
     window.addEventListener("pointermove", handlePointerMove)
     window.addEventListener("pointerup", handlePointerUp)
@@ -141,8 +169,28 @@ export default function BulletinBoard({ initialItems, mode }: Props) {
         />
       )}
 
-      {/* Desktop: scaled canvas */}
-      <div ref={containerRef} className="hidden md:block w-full" style={{ height: CANVAS_H * scale }}>
+      {/* Desktop: framed canvas */}
+      <div
+        className="hidden md:block"
+        style={{
+          padding: 16,
+          background: `
+  repeating-linear-gradient(
+    89deg,
+    transparent 0px, transparent 3px,
+    rgba(0,0,0,0.06) 3px, rgba(0,0,0,0.06) 4px
+  ),
+  repeating-linear-gradient(
+    91deg,
+    transparent 0px, transparent 7px,
+    rgba(255,255,255,0.03) 7px, rgba(255,255,255,0.03) 8px
+  ),
+  linear-gradient(160deg, #6b4423 0%, #4a2f15 50%, #3a2310 100%)
+`.replace(/\s+/g, " ").trim(),
+          boxShadow: "0 20px 80px rgba(0,0,0,0.65), inset 0 1px 0 rgba(255,255,255,0.04)",
+        }}
+      >
+      <div ref={containerRef} className="w-full" style={{ height: CANVAS_H * scale }}>
         <div
           style={{
             width: CANVAS_W,
@@ -150,24 +198,12 @@ export default function BulletinBoard({ initialItems, mode }: Props) {
             transformOrigin: "top left",
             transform: `scale(${scale})`,
             position: "relative",
-            background: "#c4a06a",
-            backgroundImage:
-              "repeating-linear-gradient(45deg, #8b6914 0, #8b6914 1px, transparent 0, transparent 50%)",
-            backgroundSize: "6px 6px",
+            background: "#181818",
+            backgroundImage: "radial-gradient(circle, #252525 1px, transparent 1px)",
+            backgroundSize: "20px 20px",
           }}
           onClick={handleCanvasClick}
         >
-          <div
-            style={{
-              position: "absolute",
-              inset: 0,
-              opacity: 0.22,
-              backgroundImage:
-                "repeating-linear-gradient(45deg, #8b6914 0, #8b6914 1px, transparent 0, transparent 50%)",
-              backgroundSize: "6px 6px",
-              pointerEvents: "none",
-            }}
-          />
           {items.map((item) => (
             <BulletinItemComp
               key={item.id}
@@ -178,20 +214,43 @@ export default function BulletinBoard({ initialItems, mode }: Props) {
               onDelete={() => handleDelete(item.id)}
               onDragStart={(e) => startDrag(e, item, "drag")}
               onResizeStart={(e) => startDrag(e, item, "resize")}
-              onViewClick={() => setLightboxUrl(item.image_url)}
+              onResizeHStart={(e) => startDrag(e, item, "resize-h")}
+              onResizeVStart={(e) => startDrag(e, item, "resize-v")}
+              onRotateStart={(e) => startDrag(e, item, "rotate")}
+              onViewClick={(rect) => { setLightboxUrl(item.image_url); setLightboxOrigin(rect) }}
             />
           ))}
         </div>
       </div>
+      </div>
 
-      {/* Mobile: 2-column grid */}
+      {/* Mobile: framed grid */}
       <div
-        className="md:hidden w-full p-4"
+        className="md:hidden"
         style={{
-          background: "#c4a06a",
-          backgroundImage:
-            "repeating-linear-gradient(45deg, #8b6914 0, #8b6914 1px, transparent 0, transparent 50%)",
-          backgroundSize: "6px 6px",
+          padding: 8,
+          background: `
+  repeating-linear-gradient(
+    89deg,
+    transparent 0px, transparent 3px,
+    rgba(0,0,0,0.06) 3px, rgba(0,0,0,0.06) 4px
+  ),
+  repeating-linear-gradient(
+    91deg,
+    transparent 0px, transparent 7px,
+    rgba(255,255,255,0.03) 7px, rgba(255,255,255,0.03) 8px
+  ),
+  linear-gradient(160deg, #6b4423 0%, #4a2f15 50%, #3a2310 100%)
+`.replace(/\s+/g, " ").trim(),
+          boxShadow: "0 12px 40px rgba(0,0,0,0.6)",
+        }}
+      >
+      <div
+        className="w-full p-4"
+        style={{
+          background: "#181818",
+          backgroundImage: "radial-gradient(circle, #252525 1px, transparent 1px)",
+          backgroundSize: "20px 20px",
           minHeight: 300,
         }}
       >
@@ -215,15 +274,20 @@ export default function BulletinBoard({ initialItems, mode }: Props) {
                 <img
                   src={item.image_url}
                   alt="Announcement"
-                  style={{ width: "100%", height: "100%", objectFit: "cover", display: "block" }}
+                  style={{ width: "100%", height: "100%", objectFit: "fill", display: "block" }}
                 />
               </div>
             ))}
         </div>
       </div>
+      </div>
 
       {lightboxUrl && (
-        <BulletinLightbox imageUrl={lightboxUrl} onClose={() => setLightboxUrl(null)} />
+        <BulletinLightbox
+          imageUrl={lightboxUrl}
+          originRect={lightboxOrigin}
+          onClose={() => { setLightboxUrl(null); setLightboxOrigin(null) }}
+        />
       )}
     </div>
   )

--- a/src/components/bulletin/BulletinBoard.tsx
+++ b/src/components/bulletin/BulletinBoard.tsx
@@ -205,7 +205,7 @@ export default function BulletinBoard({ initialItems, mode }: Props) {
                   aspectRatio: "3/4",
                   cursor: "pointer",
                 }}
-                onClick={() => setLightboxUrl(item.image_url)}
+                onClick={mode === "view" ? () => setLightboxUrl(item.image_url) : undefined}
               >
                 {/* eslint-disable-next-line @next/next/no-img-element */}
                 <img

--- a/src/components/bulletin/BulletinItem.tsx
+++ b/src/components/bulletin/BulletinItem.tsx
@@ -10,7 +10,10 @@ type Props = {
   onDelete?: () => void
   onDragStart?: (e: React.PointerEvent) => void
   onResizeStart?: (e: React.PointerEvent) => void
-  onViewClick?: () => void
+  onResizeHStart?: (e: React.PointerEvent) => void
+  onResizeVStart?: (e: React.PointerEvent) => void
+  onRotateStart?: (e: React.PointerEvent) => void
+  onViewClick?: (rect: { x: number; y: number; width: number; height: number }) => void
 }
 
 export default function BulletinItem({
@@ -21,6 +24,9 @@ export default function BulletinItem({
   onDelete,
   onDragStart,
   onResizeStart,
+  onResizeHStart,
+  onResizeVStart,
+  onRotateStart,
   onViewClick,
 }: Props) {
   const style: React.CSSProperties = {
@@ -31,14 +37,24 @@ export default function BulletinItem({
     height: item.height,
     transform: `rotate(${item.rotation}deg)`,
     boxShadow: selected
-      ? "0 0 0 2px #3182ce, 4px 6px 16px rgba(0,0,0,0.45)"
+      ? "0 0 0 1px #fff, 0 0 0 2.5px rgba(0,0,0,0.3), 4px 6px 16px rgba(0,0,0,0.45)"
       : "4px 6px 16px rgba(0,0,0,0.45)",
     borderRadius: 2,
-    overflow: "hidden",
     cursor: mode === "edit" ? "grab" : "pointer",
     userSelect: "none",
     touchAction: "none",
   }
+
+  const dot = (extra: React.CSSProperties): React.CSSProperties => ({
+    position: "absolute",
+    width: 12,
+    height: 12,
+    borderRadius: "50%",
+    background: "#fff",
+    boxShadow: "0 1px 4px rgba(0,0,0,0.35)",
+    zIndex: 10,
+    ...extra,
+  })
 
   function handlePointerDown(e: React.PointerEvent) {
     if (mode === "edit") {
@@ -51,63 +67,93 @@ export default function BulletinItem({
     <div
       style={style}
       onPointerDown={handlePointerDown}
-      onClick={mode === "view" ? onViewClick : undefined}
+      onClick={mode === "view" ? (e) => {
+        const r = e.currentTarget.getBoundingClientRect()
+        onViewClick?.({ x: r.x, y: r.y, width: r.width, height: r.height })
+      } : undefined}
     >
-      {/* eslint-disable-next-line @next/next/no-img-element */}
-      <img
-        src={item.image_url}
-        alt="Announcement"
-        style={{ width: "100%", height: "100%", objectFit: "cover", display: "block" }}
-        draggable={false}
-      />
+      <div style={{ width: "100%", height: "100%", overflow: "hidden", borderRadius: 2 }}>
+        {/* eslint-disable-next-line @next/next/no-img-element */}
+        <img
+          src={item.image_url}
+          alt="Announcement"
+          style={{ width: "100%", height: "100%", objectFit: "fill", display: "block" }}
+          draggable={false}
+        />
+      </div>
+
+      {/* Push pin — view mode only (edit mode uses the rotate handle in the same spot) */}
+      {mode === "view" && (
+        <div
+          style={{
+            position: "absolute",
+            top: -10,
+            left: "50%",
+            transform: "translateX(-50%)",
+            width: 14,
+            height: 14,
+            borderRadius: "50%",
+            background: "radial-gradient(circle at 38% 35%, #e8e8e8, #888 55%, #555)",
+            boxShadow: "0 2px 5px rgba(0,0,0,0.6), inset 0 1px 1px rgba(255,255,255,0.25)",
+            zIndex: 10,
+            pointerEvents: "none",
+          }}
+        />
+      )}
 
       {mode === "edit" && selected && (
         <>
+          {/* Delete */}
           <button
             style={{
               position: "absolute",
               top: -10,
               right: -10,
-              width: 22,
-              height: 22,
+              width: 20,
+              height: 20,
               borderRadius: "50%",
-              background: "#e53e3e",
-              color: "white",
+              background: "#fff",
+              color: "#111",
               border: "none",
-              fontSize: 14,
+              fontSize: 13,
               lineHeight: 1,
+              paddingTop: 2,
               cursor: "pointer",
               display: "flex",
               alignItems: "center",
               justifyContent: "center",
               zIndex: 10,
-              boxShadow: "0 1px 4px rgba(0,0,0,0.3)",
+              boxShadow: "0 1px 4px rgba(0,0,0,0.35)",
+              transform: `rotate(${-item.rotation}deg)`,
             }}
             onPointerDown={(e) => e.stopPropagation()}
-            onClick={(e) => {
-              e.stopPropagation()
-              onDelete?.()
-            }}
+            onClick={(e) => { e.stopPropagation(); onDelete?.() }}
           >
             ×
           </button>
 
+          {/* Rotate handle */}
           <div
-            style={{
-              position: "absolute",
-              bottom: -6,
-              right: -6,
-              width: 14,
-              height: 14,
-              borderRadius: "50%",
-              background: "#3182ce",
-              cursor: "se-resize",
-              zIndex: 10,
-            }}
-            onPointerDown={(e) => {
-              e.stopPropagation()
-              onResizeStart?.(e)
-            }}
+            style={dot({ top: -28, left: "50%", transform: "translateX(-50%)", cursor: "grab" })}
+            onPointerDown={(e) => { e.stopPropagation(); onRotateStart?.(e) }}
+          />
+
+          {/* Right-edge resize (width only) */}
+          <div
+            style={dot({ right: -6, top: "50%", transform: "translateY(-50%)", cursor: "e-resize" })}
+            onPointerDown={(e) => { e.stopPropagation(); onResizeHStart?.(e) }}
+          />
+
+          {/* Bottom-edge resize (height only) */}
+          <div
+            style={dot({ bottom: -6, left: "50%", transform: "translateX(-50%)", cursor: "s-resize" })}
+            onPointerDown={(e) => { e.stopPropagation(); onResizeVStart?.(e) }}
+          />
+
+          {/* Corner resize (aspect-ratio locked) */}
+          <div
+            style={dot({ bottom: -6, right: -6, cursor: "se-resize" })}
+            onPointerDown={(e) => { e.stopPropagation(); onResizeStart?.(e) }}
           />
         </>
       )}

--- a/src/components/bulletin/BulletinItem.tsx
+++ b/src/components/bulletin/BulletinItem.tsx
@@ -1,0 +1,116 @@
+"use client"
+
+import type { BulletinItem as Item } from "@/types/bulletin"
+
+type Props = {
+  item: Item
+  mode: "view" | "edit"
+  selected?: boolean
+  onSelect?: () => void
+  onDelete?: () => void
+  onDragStart?: (e: React.PointerEvent) => void
+  onResizeStart?: (e: React.PointerEvent) => void
+  onViewClick?: () => void
+}
+
+export default function BulletinItem({
+  item,
+  mode,
+  selected = false,
+  onSelect,
+  onDelete,
+  onDragStart,
+  onResizeStart,
+  onViewClick,
+}: Props) {
+  const style: React.CSSProperties = {
+    position: "absolute",
+    left: item.x,
+    top: item.y,
+    width: item.width,
+    height: item.height,
+    transform: `rotate(${item.rotation}deg)`,
+    boxShadow: selected
+      ? "0 0 0 2px #3182ce, 4px 6px 16px rgba(0,0,0,0.45)"
+      : "4px 6px 16px rgba(0,0,0,0.45)",
+    borderRadius: 2,
+    overflow: "hidden",
+    cursor: mode === "edit" ? "grab" : "pointer",
+    userSelect: "none",
+    touchAction: "none",
+  }
+
+  function handlePointerDown(e: React.PointerEvent) {
+    if (mode === "edit") {
+      onSelect?.()
+      onDragStart?.(e)
+    }
+  }
+
+  return (
+    <div
+      style={style}
+      onPointerDown={handlePointerDown}
+      onClick={mode === "view" ? onViewClick : undefined}
+    >
+      {/* eslint-disable-next-line @next/next/no-img-element */}
+      <img
+        src={item.image_url}
+        alt="Announcement"
+        style={{ width: "100%", height: "100%", objectFit: "cover", display: "block" }}
+        draggable={false}
+      />
+
+      {mode === "edit" && selected && (
+        <>
+          <button
+            style={{
+              position: "absolute",
+              top: -10,
+              right: -10,
+              width: 22,
+              height: 22,
+              borderRadius: "50%",
+              background: "#e53e3e",
+              color: "white",
+              border: "none",
+              fontSize: 14,
+              lineHeight: 1,
+              cursor: "pointer",
+              display: "flex",
+              alignItems: "center",
+              justifyContent: "center",
+              zIndex: 10,
+              boxShadow: "0 1px 4px rgba(0,0,0,0.3)",
+            }}
+            onPointerDown={(e) => e.stopPropagation()}
+            onClick={(e) => {
+              e.stopPropagation()
+              onDelete?.()
+            }}
+          >
+            ×
+          </button>
+
+          <div
+            style={{
+              position: "absolute",
+              bottom: -6,
+              right: -6,
+              width: 14,
+              height: 14,
+              borderRadius: "50%",
+              background: "#3182ce",
+              cursor: "se-resize",
+              zIndex: 10,
+            }}
+            onPointerDown={(e) => {
+              e.stopPropagation()
+              onResizeStart?.(e)
+            }}
+          />
+        </>
+      )}
+    </div>
+  )
+}

--- a/src/components/bulletin/BulletinLightbox.tsx
+++ b/src/components/bulletin/BulletinLightbox.tsx
@@ -1,39 +1,203 @@
 "use client"
 
-import { useEffect } from "react"
+import { useEffect, useRef, useState } from "react"
+
+type OriginRect = { x: number; y: number; width: number; height: number }
 
 type Props = {
   imageUrl: string
+  originRect?: OriginRect | null
   onClose: () => void
 }
 
-export default function BulletinLightbox({ imageUrl, onClose }: Props) {
+export default function BulletinLightbox({ imageUrl, originRect, onClose }: Props) {
+  const imgRef = useRef<HTMLImageElement>(null)
+  const overlayRef = useRef<HTMLDivElement>(null)
+  const closingRef = useRef(false)
+  const [zoom, setZoom] = useState(1)
+  const zoomRef = useRef(1)
+  const [pan, setPan] = useState({ x: 0, y: 0 })
+  const panRef = useRef({ x: 0, y: 0 })
+  const [isDragging, setIsDragging] = useState(false)
+  const dragStartRef = useRef<{ px: number; py: number; panX: number; panY: number } | null>(null)
+
+  useEffect(() => { zoomRef.current = zoom }, [zoom])
+  useEffect(() => { panRef.current = pan }, [pan])
+
+  function getOpenTransform(img: HTMLImageElement, origin: OriginRect) {
+    const r = img.getBoundingClientRect()
+    const scaleX = origin.width / r.width
+    const scaleY = origin.height / r.height
+    const dx = (origin.x + origin.width / 2) - (r.x + r.width / 2)
+    const dy = (origin.y + origin.height / 2) - (r.y + r.height / 2)
+    return `translate(${dx}px, ${dy}px) scale(${scaleX}, ${scaleY})`
+  }
+
+  // Open animation
   useEffect(() => {
-    function onKey(e: KeyboardEvent) {
-      if (e.key === "Escape") onClose()
+    const img = imgRef.current
+    const overlay = overlayRef.current
+    if (!img || !overlay) return
+
+    function run() {
+      const el = imgRef.current
+      const ov = overlayRef.current
+      if (!el || !ov) return
+
+      if (originRect) {
+        el.style.transition = "none"
+        el.style.transform = getOpenTransform(el, originRect)
+        requestAnimationFrame(() => requestAnimationFrame(() => {
+          ov.style.transition = "opacity 0.35s ease"
+          ov.style.opacity = "1"
+          el.style.transition = "transform 0.4s cubic-bezier(0.16, 1, 0.3, 1)"
+          el.style.transform = "none"
+        }))
+      } else {
+        requestAnimationFrame(() => {
+          ov.style.transition = "opacity 0.25s ease"
+          ov.style.opacity = "1"
+        })
+      }
     }
+
+    if (img.complete && img.naturalWidth > 0) run()
+    else img.addEventListener("load", run, { once: true })
+  }, []) // eslint-disable-line react-hooks/exhaustive-deps
+
+  // Escape key
+  useEffect(() => {
+    const onKey = (e: KeyboardEvent) => { if (e.key === "Escape") animateClose() }
     document.addEventListener("keydown", onKey)
     return () => document.removeEventListener("keydown", onKey)
-  }, [onClose])
+  }, []) // eslint-disable-line react-hooks/exhaustive-deps
+
+  // Scroll to zoom
+  useEffect(() => {
+    const overlay = overlayRef.current
+    if (!overlay) return
+    function onWheel(e: WheelEvent) {
+      e.preventDefault()
+      const delta = e.deltaY > 0 ? -0.25 : 0.25
+      setZoom(z => {
+        const next = Math.min(4, Math.max(1, z + delta))
+        if (next === 1) setPan({ x: 0, y: 0 })
+        return next
+      })
+    }
+    overlay.addEventListener("wheel", onWheel, { passive: false })
+    return () => overlay.removeEventListener("wheel", onWheel)
+  }, [])
+
+  function changeZoom(delta: number) {
+    setZoom(z => {
+      const next = Math.min(4, Math.max(1, z + delta))
+      if (next === 1) setPan({ x: 0, y: 0 })
+      return next
+    })
+  }
+
+  function handlePointerDown(e: React.PointerEvent) {
+    if (zoomRef.current <= 1) return
+    e.preventDefault()
+    e.currentTarget.setPointerCapture(e.pointerId)
+    dragStartRef.current = { px: e.clientX, py: e.clientY, panX: panRef.current.x, panY: panRef.current.y }
+    setIsDragging(true)
+  }
+
+  function handlePointerMove(e: React.PointerEvent) {
+    if (!dragStartRef.current) return
+    setPan({
+      x: dragStartRef.current.panX + (e.clientX - dragStartRef.current.px),
+      y: dragStartRef.current.panY + (e.clientY - dragStartRef.current.py),
+    })
+  }
+
+  function handlePointerUp() {
+    dragStartRef.current = null
+    setIsDragging(false)
+  }
+
+  function animateClose() {
+    if (closingRef.current) return
+    closingRef.current = true
+
+    const img = imgRef.current
+    const overlay = overlayRef.current
+    if (!img || !overlay) { onClose(); return }
+
+    overlay.style.transition = "opacity 0.25s ease"
+    overlay.style.opacity = "0"
+
+    if (zoomRef.current === 1 && originRect) {
+      img.style.transition = "transform 0.25s cubic-bezier(0.4, 0, 1, 1)"
+      img.style.transform = getOpenTransform(img, originRect)
+    }
+
+    setTimeout(onClose, 260)
+  }
 
   return (
     <div
+      ref={overlayRef}
       className="fixed inset-0 z-50 flex items-center justify-center bg-black/85"
-      onClick={onClose}
+      style={{ opacity: 0 }}
+      onClick={animateClose}
     >
+      {/* Close button */}
       <button
         className="absolute top-4 right-4 w-8 h-8 flex items-center justify-center rounded-full bg-white/10 text-white text-lg hover:bg-white/20"
-        onClick={onClose}
+        onClick={animateClose}
       >
         ×
       </button>
-      {/* eslint-disable-next-line @next/next/no-img-element */}
-      <img
-        src={imageUrl}
-        alt="Announcement poster"
-        className="max-w-[90vw] max-h-[90vh] object-contain rounded shadow-2xl"
+
+      {/* Image + zoom/pan wrapper */}
+      <div
+        style={{
+          transform: `translate(${pan.x}px, ${pan.y}px) scale(${zoom})`,
+          transition: isDragging ? "none" : "transform 0.2s ease",
+          transformOrigin: "center",
+          cursor: zoom > 1 ? (isDragging ? "grabbing" : "grab") : "default",
+        }}
         onClick={(e) => e.stopPropagation()}
-      />
+        onPointerDown={handlePointerDown}
+        onPointerMove={handlePointerMove}
+        onPointerUp={handlePointerUp}
+      >
+        {/* eslint-disable-next-line @next/next/no-img-element */}
+        <img
+          ref={imgRef}
+          src={imageUrl}
+          alt="Announcement poster"
+          className="max-w-[90vw] max-h-[90vh] object-contain rounded shadow-2xl"
+          draggable={false}
+        />
+      </div>
+
+      {/* Zoom controls */}
+      <div
+        className="absolute bottom-6 left-1/2 -translate-x-1/2 flex items-center gap-3 bg-black/50 rounded-full px-4 py-2"
+        onClick={(e) => e.stopPropagation()}
+      >
+        <button
+          className="w-7 h-7 flex items-center justify-center text-white/80 hover:text-white disabled:opacity-30 text-xl leading-none"
+          onClick={() => changeZoom(-0.5)}
+          disabled={zoom <= 1}
+        >
+          −
+        </button>
+        <span className="text-white/70 text-xs w-10 text-center tabular-nums">
+          {Math.round(zoom * 100)}%
+        </span>
+        <button
+          className="w-7 h-7 flex items-center justify-center text-white/80 hover:text-white disabled:opacity-30 text-xl leading-none"
+          onClick={() => changeZoom(0.5)}
+          disabled={zoom >= 4}
+        >
+          +
+        </button>
+      </div>
     </div>
   )
 }

--- a/src/components/bulletin/BulletinLightbox.tsx
+++ b/src/components/bulletin/BulletinLightbox.tsx
@@ -1,0 +1,39 @@
+"use client"
+
+import { useEffect } from "react"
+
+type Props = {
+  imageUrl: string
+  onClose: () => void
+}
+
+export default function BulletinLightbox({ imageUrl, onClose }: Props) {
+  useEffect(() => {
+    function onKey(e: KeyboardEvent) {
+      if (e.key === "Escape") onClose()
+    }
+    document.addEventListener("keydown", onKey)
+    return () => document.removeEventListener("keydown", onKey)
+  }, [onClose])
+
+  return (
+    <div
+      className="fixed inset-0 z-50 flex items-center justify-center bg-black/85"
+      onClick={onClose}
+    >
+      <button
+        className="absolute top-4 right-4 w-8 h-8 flex items-center justify-center rounded-full bg-white/10 text-white text-lg hover:bg-white/20"
+        onClick={onClose}
+      >
+        ×
+      </button>
+      {/* eslint-disable-next-line @next/next/no-img-element */}
+      <img
+        src={imageUrl}
+        alt="Announcement poster"
+        className="max-w-[90vw] max-h-[90vh] object-contain rounded shadow-2xl"
+        onClick={(e) => e.stopPropagation()}
+      />
+    </div>
+  )
+}

--- a/src/components/bulletin/BulletinToolbar.tsx
+++ b/src/components/bulletin/BulletinToolbar.tsx
@@ -1,0 +1,50 @@
+"use client"
+
+import { useRef } from "react"
+
+type Props = {
+  itemCount: number
+  saving: boolean
+  onUpload: (file: File) => void
+  onSave: () => void
+}
+
+export default function BulletinToolbar({ itemCount, saving, onUpload, onSave }: Props) {
+  const inputRef = useRef<HTMLInputElement>(null)
+  const atLimit = itemCount >= 15
+
+  return (
+    <div className="flex items-center gap-3 px-4 py-2 bg-gray-900 border-b border-gray-700">
+      <span className="text-gray-400 text-xs font-semibold tracking-widest uppercase">
+        Bulletin Admin
+      </span>
+      <span className="text-gray-600 text-xs ml-1">{itemCount}/15</span>
+      <div className="flex-1" />
+      <input
+        ref={inputRef}
+        type="file"
+        accept="image/*"
+        className="hidden"
+        onChange={(e) => {
+          const file = e.target.files?.[0]
+          if (file) onUpload(file)
+          e.target.value = ""
+        }}
+      />
+      <button
+        onClick={() => !atLimit && inputRef.current?.click()}
+        disabled={atLimit}
+        className="px-3 py-1.5 text-xs font-semibold rounded bg-blue-600 text-white hover:bg-blue-700 disabled:opacity-40 disabled:cursor-not-allowed"
+      >
+        {atLimit ? "Board Full" : "+ Upload Image"}
+      </button>
+      <button
+        onClick={onSave}
+        disabled={saving}
+        className="px-3 py-1.5 text-xs font-semibold rounded bg-green-600 text-white hover:bg-green-700 disabled:opacity-60"
+      >
+        {saving ? "Saving…" : "Save Layout"}
+      </button>
+    </div>
+  )
+}

--- a/src/components/layout/Header.tsx
+++ b/src/components/layout/Header.tsx
@@ -26,6 +26,7 @@ export default function Header() {
     { href: "/visit", label: "VISIT US" },
     { href: "/beliefs", label: "OUR BELIEFS" },
     { href: "/about", label: "ABOUT US" },
+    { href: "/bulletin", label: "BULLETIN" },
     { href: "/events", label: "EVENTS" },
     { href: "/life-group", label: "LIFE GROUP" },
     { href: "/sermon", label: "SERMON SERIES" },
@@ -34,6 +35,7 @@ export default function Header() {
     { href: "/admin/events", label: "이벤트 관리" },
     { href: "/admin/weekly-paper", label: "주보 관리" },
     { href: "/admin/home-video", label: "홈 화면 영상 설정" },
+    { href: "/admin/bulletin", label: "게시판 관리" },
   ];
 
   useEffect(() => {

--- a/src/types/bulletin.ts
+++ b/src/types/bulletin.ts
@@ -1,0 +1,11 @@
+export type BulletinItem = {
+  id: string
+  image_url: string
+  x: number
+  y: number
+  width: number
+  height: number
+  rotation: number
+  z_index: number
+  created_at: string
+}


### PR DESCRIPTION
## Summary

- Adds public `/bulletin` page — drag-and-drop poster board with lightbox zoom/pan
- Adds `/admin/bulletin` editor — upload, drag, resize, rotate, and delete posters; save layout to Supabase
- Adds `게시판 관리` link to admin dashboard
- Bulletin nav link added to public header

## Stack
- Images stored in Vercel Blob
- Layout (positions, dimensions, rotation) stored in Supabase `bulletin_items` table
- API routes: `GET/POST /api/bulletin/layout`, `POST /api/bulletin/upload`, `DELETE /api/bulletin/delete/[id]`

## Fixes included
- Server pages query Supabase directly instead of HTTP-fetching own API
- `/bulletin` marked `force-dynamic` so deletions reflect immediately
- Uploaded image dimensions derived from natural aspect ratio
- `await cookies()` fix in AdminLayout for Next.js 15 compatibility

## Test plan
- [ ] Upload image in `/admin/bulletin` — appears with correct proportions
- [ ] Drag/resize/rotate, Save Layout — positions persist on `/bulletin`
- [ ] Delete poster — disappears from `/bulletin`
- [ ] Lightbox: click poster, zoom/pan, close